### PR TITLE
set-better-default: sync

### DIFF
--- a/src/jobs/python/release/poetry.yml
+++ b/src/jobs/python/release/poetry.yml
@@ -33,7 +33,7 @@ parameters:
   pypirc-config:
     description: Location of the .pypirc-file to use.
     type: string
-    default: ''
+    default: .pypirc
   version:
     description: Override the version of the uploaded artifact in pyproject.toml.
     type: string


### PR DESCRIPTION
- Switches the default for `general/python-release-poetry`.