### PR TITLE
add-testing: security

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ setup: true
 
 
 orbs:
-  dynamic: bjd2385/dynamic-continuation@3.7.1
-  general: premiscale/general@1.0.2
+  dynamic: bjd2385/dynamic-continuation@3.8.1
+  general: premiscale/general@1.0.13
   orb-tools: circleci/orb-tools@11.6.1
   slack: circleci/slack@4.12.5
 

--- a/.circleci/scripts.yml
+++ b/.circleci/scripts.yml
@@ -2,11 +2,10 @@ version: 2.1
 
 
 orbs:
-  shellcheck: circleci/shellcheck@3.1.2
+  shellcheck: circleci/shellcheck@3.2.0
 
 
 workflows:
   scripts:
     jobs:
-      - shellcheck/check:
-          exclude: SC2148
+      - shellcheck/check

--- a/.circleci/scripts.yml
+++ b/.circleci/scripts.yml
@@ -8,4 +8,6 @@ orbs:
 workflows:
   scripts:
     jobs:
-      - shellcheck/check
+      - shellcheck/check:
+          # This needs to stay on this project; src/scripts/ contains scripts that do not need a shebang.
+          exclude: SC2148

--- a/.circleci/src.yml
+++ b/.circleci/src.yml
@@ -4,7 +4,7 @@ version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@11.6.1
   circleci-cli: circleci/circleci-cli@0.1.9
-  general: premiscale/general@1.0.0
+  general: premiscale/general@1.0.13
 
 
 workflows:

--- a/.circleci/src.yml
+++ b/.circleci/src.yml
@@ -15,7 +15,7 @@ workflows:
 
       - orb-tools/review:
           exclude: ''
-          max_command_length: 1024
+          max_command_length: 4096
           resource_class: small
 
       - general/orb-pack:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
-nodejs 18.18.2
-yarn   1.22.19
+nodejs     18.18.2
+yarn       1.22.19
+shellcheck 0.9.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `general` orb for CircleCI
 
-This orb is a collection of useful commands and jobs we can reuse in many repositories to simplify configs and reduce code duplication.
+This orb is a collection of useful commands and jobs we can reuse in many repositories to simplify configs and reduce code duplication in [dynamically-continued](https://github.com/emmeowzing/dynamic-continuation-orb) pipelines.
 
 ## Development
 

--- a/src/commands/utils/install-jq.yml
+++ b/src/commands/utils/install-jq.yml
@@ -1,0 +1,14 @@
+description: Install jq
+parameters:
+  jq-version:
+    type: string
+    description: jq version to install.
+    default: 1.7.1
+steps:
+  - run:
+      name: Install jq
+      command: |+
+        curl -sL https://github.com/jqlang/jq/releases/download/jq-<< parameters.jq-version >>/jq-linux-amd64 -o jq
+        sudo install jq /usr/bin/jq
+        rm jq
+        jq --version

--- a/src/commands/utils/install-yq.yml
+++ b/src/commands/utils/install-yq.yml
@@ -1,0 +1,14 @@
+description: Install yq
+parameters:
+  yq-version:
+    type: string
+    description: yq version to install.
+    default: 4.40.5
+steps:
+  - run:
+      name: Install yq
+      command: |+
+        curl -sL https://github.com/mikefarah/yq/releases/download/v<< parameters.yq-version >>/yq_linux_amd64 -o yq
+        sudo install yq /usr/bin/yq
+        rm yq
+        yq --version

--- a/src/jobs/helm/lint.yml
+++ b/src/jobs/helm/lint.yml
@@ -21,10 +21,27 @@ parameters:
   chart-path:
     description: Path to Helm chart we wish to lint.
     type: string
-    default: helm/
+    default: ''
 steps:
   - checkout
   - helm/install-helm-client
-  - run:
-      name: Helm lint
-      command: helm lint << parameters.chart-path >>
+  # When there's a chart path specified.
+  - when:
+      condition: << parameters.chart-path >>
+      steps:
+        - run:
+            name: Helm lint
+            command: |+
+              helm lint << parameters.chart-path >>
+  #
+  - unless:
+      condition: << parameters.chart-path >>
+      steps:
+        - run:
+            name: Helm lint
+            command: |+
+              mapfile -t _HELM_CHART_DIRECTORIES < <(find -type f -name "Chart.yaml" -exec dirname {} \;)
+
+              for chart_path in "${_HELM_CHART_DIRECTORIES[@]}"; do
+                  helm lint "$chart_path"
+              done

--- a/src/jobs/helm/release/nexus.yml
+++ b/src/jobs/helm/release/nexus.yml
@@ -65,11 +65,7 @@ steps:
       condition:
         equal: [<< parameters.image-tag >>, '']
       steps:
-        - run:
-            name: Install yq
-            command: |
-              curl -sL https://github.com/mikefarah/yq/releases/download/v4.30.6/yq_linux_amd64 --out yq
-              sudo install --compare yq /usr/local/bin/yq || true
+        - utils/install-yq
         - run:
             name: Update image tag
             command: |

--- a/src/jobs/helm/release/nexus.yml
+++ b/src/jobs/helm/release/nexus.yml
@@ -65,7 +65,7 @@ steps:
       condition:
         equal: [<< parameters.image-tag >>, '']
       steps:
-        - utils/install-yq
+        - utils-install-yq
         - run:
             name: Update image tag
             command: |

--- a/src/jobs/helm/test/deprecated.yml
+++ b/src/jobs/helm/test/deprecated.yml
@@ -1,0 +1,48 @@
+description: |+
+  Run pluto against all Helm charts in a project.
+executor: << parameters.executor >>
+resource_class: << parameters.resource-class >>
+parameters:
+  resource-class:
+    type: enum
+    enum:
+      - small
+      - medium
+      - large
+      - xlarge
+      - 2xlarge
+      - premiscale/on-premise
+    default: small
+    description: Resource class to run as.
+  pluto-version:
+    description: Version of pluto to install.
+    default: 5.19.0
+    type: string
+  excludes:
+    description: Exclude is a list of check names to exclude.
+    default: ''
+    type: string
+  executor:
+    description: Executor image to run as.
+    default: default
+    type: executor
+steps:
+  - checkout
+  - run:
+      name: Install pluto
+      command: |+
+        curl -sL https://github.com/FairwindsOps/pluto/releases/download/v<< parameters.pluto-version >>/pluto_<< parameters.pluto-version >>_linux_amd64.tar.gz -o pluto.tar.gz
+        mkdir pluto/
+        tar -zxvf pluto.tar.gz -C pluto/
+        sudo install pluto/pluto /usr/bin/pluto
+        rm -rf pluto/ pluto.tar.gz
+  - run:
+      name: pluto
+      description: Run pluto against all charts in a repository.
+      command: |+
+          mapfile -t _HELM_CHART_DIRECTORIES < <(find -type f -name "Chart.yaml" -exec dirname {} \;)
+
+          for chart_path in "${_HELM_CHART_DIRECTORIES[@]}"; do
+              printf "INFO: Testing Helm chart at \"%s\" for deprecated API versions.\\n"
+              helm template "$chart_path" | pluto detect -
+          done

--- a/src/jobs/helm/test/deprecated.yml
+++ b/src/jobs/helm/test/deprecated.yml
@@ -28,6 +28,7 @@ parameters:
     type: executor
 steps:
   - checkout
+  - helm/install-helm-client
   - run:
       name: Install pluto
       command: |+

--- a/src/jobs/helm/test/kubelinter.yml
+++ b/src/jobs/helm/test/kubelinter.yml
@@ -18,7 +18,7 @@ parameters:
     description: Version of kubelinter to install.
     default: 0.6.5
     type: string
-  excludes:
+  exclude:
     description: Exclude is a list of check names to exclude.
     default: ''
     type: string

--- a/src/jobs/helm/test/kubelinter.yml
+++ b/src/jobs/helm/test/kubelinter.yml
@@ -1,0 +1,41 @@
+description: |+
+  Run kubelinter against all Helm charts in a project.
+executor: << parameters.executor >>
+resource_class: << parameters.resource-class >>
+parameters:
+  resource-class:
+    type: enum
+    enum:
+      - small
+      - medium
+      - large
+      - xlarge
+      - 2xlarge
+      - premiscale/on-premise
+    default: small
+    description: Resource class to run as.
+  kubelinter-version:
+    description: Version of kubelinter to install.
+    default: 0.6.5
+    type: string
+  excludes:
+    description: Exclude is a list of check names to exclude.
+    default: ''
+    type: string
+  executor:
+    description: Executor image to run as.
+    default: default
+    type: executor
+steps:
+  - checkout
+  - run:
+      name: Install kubelinter
+      command: |+
+        curl -sL https://github.com/stackrox/kube-linter/releases/download/v<< parameters.kubelinter-version >>/kube-linter-linux -o kubelinter
+        sudo install kubelinter /usr/bin/kubelinter
+        rm -rf kubelinter
+  - run:
+      name: kubelinter
+      description: Run tests against a variety of Kubernetes versions and charts.
+      command: |+
+        kubelinter . --exclude << parameters.exclude >>

--- a/src/jobs/helm/test/kubelinter.yml
+++ b/src/jobs/helm/test/kubelinter.yml
@@ -34,8 +34,19 @@ steps:
         curl -sL https://github.com/stackrox/kube-linter/releases/download/v<< parameters.kubelinter-version >>/kube-linter-linux -o kubelinter
         sudo install kubelinter /usr/bin/kubelinter
         rm -rf kubelinter
-  - run:
-      name: kubelinter
-      description: Run kubelinter against all charts in a repository.
-      command: |+
-        kubelinter . --exclude << parameters.exclude >>
+  - when:
+      condition: << parameters.exclude >>
+      steps:
+        - run:
+            name: kubelinter
+            description: Run kubelinter against all charts in a repository.
+            command: |+
+              kubelinter lint . --exclude << parameters.exclude >>
+  - unless:
+      condition: << parameters.exclude >>
+      steps:
+        - run:
+            name: kubelinter
+            description: Run kubelinter against all charts in a repository.
+            command: |+
+              kubelinter lint .

--- a/src/jobs/helm/test/kubelinter.yml
+++ b/src/jobs/helm/test/kubelinter.yml
@@ -36,6 +36,6 @@ steps:
         rm -rf kubelinter
   - run:
       name: kubelinter
-      description: Run tests against a variety of Kubernetes versions and charts.
+      description: Run kubelinter against all charts in a repository.
       command: |+
         kubelinter . --exclude << parameters.exclude >>

--- a/src/jobs/helm/test/kubesec.yml
+++ b/src/jobs/helm/test/kubesec.yml
@@ -51,9 +51,8 @@ steps:
         rm -rf kubesec/
   - run:
       name: 'Pre: define test function'
+      description: Test that the manifests are both valid and meet our minimum scoring requirement across supported Kubernetes versions.
       command: |+
-        ##
-        # Test that the manifests are both valid and meet our minimum scoring requirement across supported Kubernetes versions.
         test()
         {
             if [ $# -ne 2 ]; then
@@ -90,6 +89,7 @@ steps:
         }
   - run:
       name: kubesec
+      description: Run tests against a variety of Kubernetes versions and charts.
       command: |+
         mapfile -t -d " " _TARGET_KUBERNETES_VERSIONS < <(printf "%s" "<< parameters.kubernetes-versions >>")
         mapfile -t _HELM_CHART_DIRECTORIES < <(find -type f -name "Chart.yaml" -exec dirname {} \;)

--- a/src/jobs/helm/test/kubesec.yml
+++ b/src/jobs/helm/test/kubesec.yml
@@ -89,7 +89,7 @@ steps:
         }
   - run:
       name: kubesec
-      description: Run tests against a variety of Kubernetes versions and charts.
+      description: Run kubesec against a variety of Kubernetes versions and charts.
       command: |+
         mapfile -t -d " " _TARGET_KUBERNETES_VERSIONS < <(printf "%s" "<< parameters.kubernetes-versions >>")
         mapfile -t _HELM_CHART_DIRECTORIES < <(find -type f -name "Chart.yaml" -exec dirname {} \;)

--- a/src/jobs/helm/test/kubesec.yml
+++ b/src/jobs/helm/test/kubesec.yml
@@ -60,8 +60,6 @@ steps:
                 exit 1
             fi
 
-            printf "INFO: running kubesec against chart located at \"%s\" K8s v%s\\n" "$chart_path" "$kubernetes_version"
-
             local chart_path kubernetes_version report results results_length i score
 
             chart_path="$1"
@@ -69,6 +67,8 @@ steps:
             report="$(helm template "$chart_path" | kubesec scan - --kubernetes-version "$kubernetes_version" --schema-location default << parameters.add-schema >> || true)"
             results="$(printf "%s" "$report" | jq -r '{ "results": [ .[] | { "type": .object, "valid": .valid, "score": .score } ] }')"
             results_length="$(printf "%s" "$results" | jq -r '.results | length')"
+
+            printf "INFO: running kubesec against chart located at \"%s\" K8s v%s\\n" "$chart_path" "$kubernetes_version"
 
             for (( i=0; i<results_length; i++ )); do
                 # kubeconform: test that the manifest is actually a valid kubernetes manifest for this version of K8s.

--- a/src/jobs/helm/test/kubesec.yml
+++ b/src/jobs/helm/test/kubesec.yml
@@ -64,6 +64,7 @@ steps:
 
             chart_path="$1"
             kubernetes_version="$2"
+
             report="$(helm template "$chart_path" | kubesec scan - --kubernetes-version "$kubernetes_version" --schema-location default << parameters.kubeconform-schema >> || true)"
             results="$(printf "%s" "$report" | jq -r '{ "results": [ .[] | { "type": .object, "valid": .valid, "score": .score } ] }')"
             results_length="$(printf "%s" "$results" | jq -r '.results | length')"
@@ -95,7 +96,7 @@ steps:
         mapfile -t _HELM_CHART_DIRECTORIES < <(find -type f -name "Chart.yaml" -exec dirname {} \;)
 
         for chart_path in "${_HELM_CHART_DIRECTORIES[@]}"; do
-            for version in "${_TARGET_KUBERNETES_VERSIONS[@]}"; do
+            for kubernetes_version in "${_TARGET_KUBERNETES_VERSIONS[@]}"; do
                 test "$chart_path" "$kubernetes_version"
             done
         done

--- a/src/jobs/helm/test/kubesec.yml
+++ b/src/jobs/helm/test/kubesec.yml
@@ -97,6 +97,7 @@ steps:
 
         for chart_path in "${_HELM_CHART_DIRECTORIES[@]}"; do
             for kubernetes_version in "${_TARGET_KUBERNETES_VERSIONS[@]}"; do
+                printf "kubesec: testing \"%s\" on k8s version \"%s\"" "$chart_path" "$kubernetes_version"
                 test "$chart_path" "$kubernetes_version"
             done
         done

--- a/src/jobs/helm/test/kubesec.yml
+++ b/src/jobs/helm/test/kubesec.yml
@@ -23,6 +23,8 @@ parameters:
       Add additional schema, such as Bitnami CRDs for SealedSecrets:
 
         '--schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/bitnami.com/sealedsecret_v1alpha1.json'
+
+      Note: the schema MUST be in JSON format, otherwise kubesec will just ignore it.
     type: string
     default: ''
   kubesec-version:

--- a/src/jobs/helm/test/kubesec.yml
+++ b/src/jobs/helm/test/kubesec.yml
@@ -40,7 +40,7 @@ parameters:
 steps:
   - checkout
   - helm/install-helm-client
-  - utils/install-jq
+  - utils-install-jq
   - run:
       name: Install kubesec
       command: |+
@@ -64,7 +64,7 @@ steps:
 
             chart_path="$1"
             kubernetes_version="$2"
-            report="$(helm template "$chart_path" | kubesec scan - --kubernetes-version "$kubernetes_version" --schema-location default << parameters.add-schema >> || true)"
+            report="$(helm template "$chart_path" | kubesec scan - --kubernetes-version "$kubernetes_version" --schema-location default << parameters.kubeconform-schema >> || true)"
             results="$(printf "%s" "$report" | jq -r '{ "results": [ .[] | { "type": .object, "valid": .valid, "score": .score } ] }')"
             results_length="$(printf "%s" "$results" | jq -r '.results | length')"
 

--- a/src/jobs/helm/test/kubesec.yml
+++ b/src/jobs/helm/test/kubesec.yml
@@ -50,45 +50,6 @@ steps:
         sudo install kubesec/kubesec /usr/bin/kubesec
         rm -rf kubesec/
   - run:
-      name: 'Pre: define test function'
-      description: Test that the manifests are both valid and meet our minimum scoring requirement across supported Kubernetes versions.
-      command: |+
-        test()
-        {
-            if [ $# -ne 2 ]; then
-                printf "Function \"test\" expected 2 arguments: Helm chart path, Kubernetes version.\\n" >&2
-                exit 1
-            fi
-
-            local chart_path kubernetes_version report results results_length i score
-
-            chart_path="$1"
-            kubernetes_version="$2"
-
-            report="$(helm template "$chart_path" | kubesec scan - --kubernetes-version "$kubernetes_version" --schema-location default << parameters.kubeconform-schema >> || true)"
-            results="$(printf "%s" "$report" | jq -r '{ "results": [ .[] | { "type": .object, "valid": .valid, "score": .score } ] }')"
-            results_length="$(printf "%s" "$results" | jq -r '.results | length')"
-
-            printf "INFO: running kubesec against chart located at \"%s\" K8s v%s\\n" "$chart_path" "$kubernetes_version"
-
-            for (( i=0; i<results_length; i++ )); do
-                # kubeconform: test that the manifest is actually a valid kubernetes manifest for this version of K8s.
-                if [ "$(printf "%s" "$results" | jq -r ".results[$i].valid")" != "true" ]; then
-                    printf "ERROR: manifest \"%s\" on chart \"%s\" is not valid on Kubernetes version \"%s\".\\n" "$(printf "%s" "$results" | jq -r ".results[$i].type")" "$chart_path" "$kubernetes_version" >&2
-                    printf "%s\\n" "$report"
-                    exit 1
-                fi
-
-                # Test that the kubesec score meets our minimum requirement.
-                score="$(printf "%s" "$results" | jq -r ".results[$i].score")"
-                if [ "$score" -lt "<< parameters.minimum-score >>" ]; then
-                    printf "ERROR: manifest \"%s\" on chart \"%s\" does not meet minimum score \"%i\" on Kubernetes version \"%s\".\\n" "$(printf "%s" "$results" | jq -r ".results[$i].type")" "$chart_path" "<< parameters.minimum-score >>" "$kubernetes_version" >&2
-                    printf "%s\\n" "$report"
-                    exit 1
-                fi
-            done
-        }
-  - run:
       name: kubesec
       description: Run kubesec against a variety of Kubernetes versions and charts.
       command: |+
@@ -97,7 +58,27 @@ steps:
 
         for chart_path in "${_HELM_CHART_DIRECTORIES[@]}"; do
             for kubernetes_version in "${_TARGET_KUBERNETES_VERSIONS[@]}"; do
-                printf "kubesec: testing \"%s\" on k8s version \"%s\"" "$chart_path" "$kubernetes_version"
-                test "$chart_path" "$kubernetes_version"
+                printf "kubesec: testing \"%s\" on k8s version \"%s\"\\n" "$chart_path" "$kubernetes_version"
+
+                report="$(helm template "$chart_path" | kubesec scan - --kubernetes-version "$kubernetes_version" --schema-location default << parameters.kubeconform-schema >> || true)"
+                results="$(printf "%s" "$report" | jq -r '{ "results": [ .[] | { "type": .object, "valid": .valid, "score": .score } ] }')"
+                results_length="$(printf "%s" "$results" | jq -r '.results | length')"
+
+                for (( i=0; i<results_length; i++ )); do
+                    # kubeconform: test that the manifest is actually a valid kubernetes manifest for this version of K8s.
+                    if [ "$(printf "%s" "$results" | jq -r ".results[$i].valid")" != "true" ]; then
+                        printf "ERROR: manifest \"%s\" on chart \"%s\" is not valid on Kubernetes version \"%s\".\\n" "$(printf "%s" "$results" | jq -r ".results[$i].type")" "$chart_path" "$kubernetes_version" >&2
+                        printf "%s\\n" "$report"
+                        exit 1
+                    fi
+
+                    # Test that the kubesec score meets our minimum requirement.
+                    score="$(printf "%s" "$results" | jq -r ".results[$i].score")"
+                    if [ "$score" -lt "<< parameters.minimum-score >>" ]; then
+                        printf "ERROR: manifest \"%s\" on chart \"%s\" does not meet minimum score \"%i\" on Kubernetes version \"%s\".\\n" "$(printf "%s" "$results" | jq -r ".results[$i].type")" "$chart_path" "<< parameters.minimum-score >>" "$kubernetes_version" >&2
+                        printf "%s\\n" "$report"
+                        exit 1
+                    fi
+                done
             done
         done

--- a/src/jobs/helm/test/kubesec.yml
+++ b/src/jobs/helm/test/kubesec.yml
@@ -1,0 +1,101 @@
+description: |+
+  Run kubesec against all Helm charts in a project.
+executor: << parameters.executor >>
+resource_class: << parameters.resource-class >>
+parameters:
+  minimum-score:
+    description: Minimum kubesec score for every chart to pass the job.
+    type: integer
+    default: 0
+  resource-class:
+    type: enum
+    enum:
+      - small
+      - medium
+      - large
+      - xlarge
+      - 2xlarge
+      - premiscale/on-premise
+    default: small
+    description: Resource class to run as.
+  kubeconform-schema:
+    description: |+
+      Add additional schema, such as Bitnami CRDs for SealedSecrets:
+
+        '--schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/bitnami.com/sealedsecret_v1alpha1.json'
+    type: string
+    default: ''
+  kubesec-version:
+    description: Version of kubesec to install.
+    default: 2.14.0
+    type: string
+  kubernetes-versions:
+    description: A space-delimited set of Kubernetes versions to check schema (kubeconform) against.
+    type: string
+    default: '1.24.17 1.25.16 1.26.11 1.27.8 1.28.4'
+  executor:
+    description: Executor image to run as.
+    default: default
+    type: executor
+steps:
+  - checkout
+  - helm/install-helm-client
+  - utils/install-jq
+  - run:
+      name: Install kubesec
+      command: |+
+        curl -sL https://github.com/controlplaneio/kubesec/releases/download/v<< parameters.kubesec-version >>/kubesec_linux_amd64.tar.gz -o kubesec.tar.gz
+        mkdir kubesec/
+        tar -zxvf kubesec.tar.gz -C kubesec/
+        sudo install kubesec/kubesec /usr/bin/kubesec
+        rm -rf kubesec/
+  - run:
+      name: 'Pre: define test function'
+      command: |+
+        ##
+        # Test that the manifests are both valid and meet our minimum scoring requirement across supported Kubernetes versions.
+        test()
+        {
+            if [ $# -ne 2 ]; then
+                printf "Function \"test\" expected 2 arguments: Helm chart path, Kubernetes version.\\n" >&2
+                exit 1
+            fi
+
+            printf "INFO: running kubesec against chart located at \"%s\" K8s v%s\\n" "$chart_path" "$kubernetes_version"
+
+            local chart_path kubernetes_version report results results_length i score
+
+            chart_path="$1"
+            kubernetes_version="$2"
+            report="$(helm template "$chart_path" | kubesec scan - --kubernetes-version "$kubernetes_version" --schema-location default << parameters.add-schema >> || true)"
+            results="$(printf "%s" "$report" | jq -r '{ "results": [ .[] | { "type": .object, "valid": .valid, "score": .score } ] }')"
+            results_length="$(printf "%s" "$results" | jq -r '.results | length')"
+
+            for (( i=0; i<results_length; i++ )); do
+                # kubeconform: test that the manifest is actually a valid kubernetes manifest for this version of K8s.
+                if [ "$(printf "%s" "$results" | jq -r ".results[$i].valid")" != "true" ]; then
+                    printf "ERROR: manifest \"%s\" on chart \"%s\" is not valid on Kubernetes version \"%s\".\\n" "$(printf "%s" "$results" | jq -r ".results[$i].type")" "$chart_path" "$kubernetes_version" >&2
+                    printf "%s\\n" "$report"
+                    exit 1
+                fi
+
+                # Test that the kubesec score meets our minimum requirement.
+                score="$(printf "%s" "$results" | jq -r ".results[$i].score")"
+                if [ "$score" -lt "<< parameters.minimum-score >>" ]; then
+                    printf "ERROR: manifest \"%s\" on chart \"%s\" does not meet minimum score \"%i\" on Kubernetes version \"%s\".\\n" "$(printf "%s" "$results" | jq -r ".results[$i].type")" "$chart_path" "<< parameters.minimum-score >>" "$kubernetes_version" >&2
+                    printf "%s\\n" "$report"
+                    exit 1
+                fi
+            done
+        }
+  - run:
+      name: kubesec
+      command: |+
+        mapfile -t -d " " _TARGET_KUBERNETES_VERSIONS < <(printf "%s" "<< parameters.kubernetes-versions >>")
+        mapfile -t _HELM_CHART_DIRECTORIES < <(find -type f -name "Chart.yaml" -exec dirname {} \;)
+
+        for chart_path in "${_HELM_CHART_DIRECTORIES[@]}"; do
+            for version in "${_TARGET_KUBERNETES_VERSIONS[@]}"; do
+                test "$chart_path" "$kubernetes_version"
+            done
+        done

--- a/src/jobs/helm/upgrade.yml
+++ b/src/jobs/helm/upgrade.yml
@@ -81,8 +81,8 @@ executor: << parameters.executor >>
 steps:
   - checkout
   - helm/install-helm-client
-  - when:
-      condition: << parameter.uninstall-prev-name >>
+  - unless:
+      condition: << parameters.uninstall-prev-name >>
       steps:
         - run:
             name: Uninstall previous managed installation

--- a/src/scripts/pre-pack.sh
+++ b/src/scripts/pre-pack.sh
@@ -1,6 +1,8 @@
 # Reduce nested commands and jobs to files under src/commands or src/jobs so they can be packed by 'circleci orb pack src/'.
 # Allows you to group collections of commands under directories.
 
+# shellcheck disable=SC2216,SC2148
+
 pre-pack()
 {
     local current_directory="$1"

--- a/src/scripts/rev-pack.sh
+++ b/src/scripts/rev-pack.sh
@@ -1,7 +1,7 @@
 # Reverse operation of pre-pack.sh. If files exist with a prefix that matches a directory name, they'll be moved under
 # that directory, and the prefix removed.
 
-# shellcheck disable=SC2216
+# shellcheck disable=SC2216,SC2148
 
 # Force deletion of files even if checksums (i.e. their contents) don't match.
 FORCE="${1:-false}"


### PR DESCRIPTION
Adding the following new jobs for Helm / Docker repositories:

- kubesec (kubeconform, security unit testing)
- kubelinter (best practices)
- pluto (API deprecation)

It also generalizes `helm lint` to linting all located Helm charts in a project in a single job, so there's no need to matrix over paths (which is costly and silly for such an inexpensive operation).